### PR TITLE
chore: move core dependencies to peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,11 @@
 			"workspaces": [
 				"packages/**"
 			],
+			"dependencies": {
+				"eslint": "^8.47.0",
+				"markdownlint-cli2": "^0.8.1",
+				"stylelint": "^15.10.2"
+			},
 			"devDependencies": {
 				"eslint-config-neoncitylights": "link:packages/eslint-config",
 				"markdownlint-config-neoncitylights": "link:packages/markdownlint-config",
@@ -5413,7 +5418,6 @@
 			"dependencies": {
 				"@typescript-eslint/eslint-plugin": "^6.3.0",
 				"@typescript-eslint/parser": "^6.3.0",
-				"eslint": "^8.47.0",
 				"eslint-plugin-jsx-a11y": "^6.7.1",
 				"eslint-plugin-no-jquery": "^2.7.0",
 				"eslint-plugin-node": "^11.1.0",
@@ -5430,26 +5434,28 @@
 			"funding": {
 				"type": "individual",
 				"url": "https://github.com/sponsors/neoncitylights"
+			},
+			"peerDependencies": {
+				"eslint": "^8.x"
 			}
 		},
 		"packages/markdownlint-config": {
 			"name": "markdownlint-config-neoncitylights",
 			"version": "0.0.0",
 			"license": "MIT",
-			"dependencies": {
-				"markdownlint-cli2": "^0.8.1"
-			},
 			"funding": {
 				"type": "individual",
 				"url": "https://github.com/sponsors/neoncitylights"
+			},
+			"peerDependencies": {
+				"markdownlint-cli2": "^0.8.x"
 			}
 		},
 		"packages/stylelint-config": {
 			"name": "stylelint-config-neoncitylights",
-			"version": "0.1.0",
+			"version": "0.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"stylelint": "^15.10.2",
 				"stylelint-config-css-modules": "^4.3.0",
 				"stylelint-config-recommended": "^13.0.0",
 				"stylelint-config-standard-scss": "^10.0.0",
@@ -5460,6 +5466,9 @@
 			"funding": {
 				"type": "individual",
 				"url": "https://github.com/sponsors/neoncitylights"
+			},
+			"peerDependencies": {
+				"stylelint": "^15.x"
 			}
 		}
 	},
@@ -6637,7 +6646,6 @@
 			"requires": {
 				"@typescript-eslint/eslint-plugin": "^6.3.0",
 				"@typescript-eslint/parser": "^6.3.0",
-				"eslint": "^8.47.0",
 				"eslint-plugin-jsx-a11y": "^6.7.1",
 				"eslint-plugin-no-jquery": "^2.7.0",
 				"eslint-plugin-node": "^11.1.0",
@@ -7770,9 +7778,7 @@
 		},
 		"markdownlint-config-neoncitylights": {
 			"version": "file:packages/markdownlint-config",
-			"requires": {
-				"markdownlint-cli2": "^0.8.1"
-			}
+			"requires": {}
 		},
 		"markdownlint-micromark": {
 			"version": "0.1.5",
@@ -8608,7 +8614,6 @@
 		"stylelint-config-neoncitylights": {
 			"version": "file:packages/stylelint-config",
 			"requires": {
-				"stylelint": "^15.10.2",
 				"stylelint-config-css-modules": "^4.3.0",
 				"stylelint-config-recommended": "^13.0.0",
 				"stylelint-config-standard-scss": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
 	},
 	"devDependencies": {
 		"eslint-config-neoncitylights": "link:packages/eslint-config",
+		"eslint": "^8.47.0",
+		"markdownlint-cli2": "^0.8.1",
 		"markdownlint-config-neoncitylights": "link:packages/markdownlint-config",
-		"stylelint-config-neoncitylights": "lint:packages/stylelint-config"
+		"stylelint-config-neoncitylights": "lint:packages/stylelint-config",
+		"stylelint": "^15.10.2"
 	}
 }

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -8,6 +8,12 @@ My personal ESLint configuration settings.
 ## Install
 
 ```shell
+npm install eslint eslint-config-neoncitylights --save-dev
+```
+
+Or, if ESLint is already installed:
+
+```shell
 npm install eslint-config-neoncitylights --save-dev
 ```
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -30,10 +30,12 @@
 		"tests.json",
 		"typescript.json"
 	],
+	"peerDependencies": {
+		"eslint": "^8.x"
+	},
 	"dependencies": {
 		"@typescript-eslint/eslint-plugin": "^6.3.0",
 		"@typescript-eslint/parser": "^6.3.0",
-		"eslint": "^8.47.0",
 		"eslint-plugin-jsx-a11y": "^6.7.1",
 		"eslint-plugin-no-jquery": "^2.7.0",
 		"eslint-plugin-node": "^11.1.0",

--- a/packages/markdownlint-config/README.md
+++ b/packages/markdownlint-config/README.md
@@ -8,6 +8,12 @@ My personal Markdownlint configuration settings.
 ## Install
 
 ```shell
+npm install markdownlint-cli2 markdown-config-neoncitylights --save-dev
+```
+
+Or, if markdownlint is already installed:
+
+```shell
 npm install markdown-config-neoncitylights --save-dev
 ```
 

--- a/packages/markdownlint-config/package.json
+++ b/packages/markdownlint-config/package.json
@@ -26,7 +26,7 @@
 		"index.json",
 		"mdbook.json"
 	],
-	"dependencies": {
-		"markdownlint-cli2": "^0.8.1"
+	"peerDependencies": {
+		"markdownlint-cli2": "^0.8.x"
 	}
 }

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -8,6 +8,12 @@ My personal Stylelint configuration settings.
 ## Install
 
 ```shell
+npm install stylelint stylelint-config-neoncitylights --save-dev
+```
+
+Or, if Stylelint is already installed:
+
+```shell
 npm install stylelint-config-neoncitylights --save-dev
 ```
 

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -29,8 +29,10 @@
 		"cssmodules.js",
 		"properties.json"
 	],
+	"peerDependencies": {
+		"stylelint": "^15.x"
+	},
 	"dependencies": {
-		"stylelint": "^15.10.2",
 		"stylelint-config-css-modules": "^4.3.0",
 		"stylelint-config-recommended": "^13.0.0",
 		"stylelint-config-standard-scss": "^10.0.0",


### PR DESCRIPTION
Moves eslint, markdownlint-cli2, and stylelint as peer dependencies for all packages

- https://docs.npmjs.com/cli/v9/configuring-npm/package-json#peerdependencies
- https://nodejs.org/es/blog/npm/peer-dependencies